### PR TITLE
Switch to llama.cpp for fallback LLM

### DIFF
--- a/install/installminimy
+++ b/install/installminimy
@@ -181,7 +181,7 @@ function generateServiceFiles
 
   rm -rf "$tmpDir"                         # cleanup temporary directory
   runCmd sudo systemctl daemon-reload      # reload systemd to pick up new files
-  runCmd sudo systemctl start whisper      # start whisper for this session 
+  runCmd sudo systemctl start whisper      # start whisper for this session
   echo "Systemd service files installed successfully" | tee -a $logFile
  }                                         # generateServiceFiles()
 
@@ -300,7 +300,7 @@ function buildVenv
   echo "Running $0 at `date` ..." > $logFile # create a new log file
   echo | tee -a $logFile
 
-  # Export environment variables needed by Python scripts 
+  # Export environment variables needed by Python scripts
   export SVA_BASE_DIR="$baseDir"
   export PYTHONPATH="$baseDir"
   echo "Set SVA_BASE_DIR=$baseDir" | tee -a $logFile
@@ -375,7 +375,7 @@ function buildVenv
   runCmd $pipCmd install --no-binary :all: regex # force pip to ignore old wheels and build fresh
   echo "Installing python3-lingua-franca ..." | tee -a $logFile
   runCmd $pipCmd install lingua_franca
-  runCmd $pipCmd install psutil 
+  runCmd $pipCmd install psutil
   runCmd $pipCmd install -r install/requirements.txt
   echo "Installing local STT faster-whisper" | tee -a $logFile
   runCmd $pipCmd install faster-whisper
@@ -454,35 +454,28 @@ function buildVenv
     echo "Skipping piper - already installed ..."| tee -a $logFile
   fi
 
-  echo "Installing Ollama ..." | tee -a $logFile
+  echo "Installing llama-cpp-python ..." | tee -a $logFile
   echo | tee -a $logFile
-  if [ ! -d /usr/local/lib/ollama ]; then  # get ollama install script
-    curl -fsSL https://ollama.com/install.sh | sh
-  fi
-  if [ ! -f /etc/systemd/system/ollama.service ]; then # not expected
-    echo "WARNING: file /etc/systemd/system/ollama.service not found" | tee -a $logFile
-  else                                     # add env var to allow all hosts in local subnet
-    ipAddr="0.0.0.0"                       # answer all requests
-    echo "Setting Ollama IP address to $ipAddr ..." | tee -a $logFile
-    cd /etc/systemd/system
-    sudo sed -i "/\[Service\]/a Environment=OLLAMA_HOST=$ipAddr" ollama.service # put IP@ in OLLAMA_HOST env var
-    if [ $? != 0 ]; then
-      echo "WARNING! sed to ollama.service returned $?" | tee -a $logFile
+  if grep -qi "Jetson" /proc/device-tree/model 2>/dev/null || grep -qi "Orin" /proc/device-tree/model 2>/dev/null; then
+    echo "Jetson Orin Nano detected. Installing with CUDA ..." | tee -a $logFile
+    runCmd CUDACXX=/usr/local/cuda/bin/nvcc CMAKE_ARGS="-DGGML_CUDA=on" FORCE_CMAKE=1 $pipCmd install llama-cpp-python huggingface_hub
+  else
+    echo "Installing with OpenBLAS ..." | tee -a $logFile
+    if command -v apt-get &>/dev/null; then
+      runCmd sudo apt-get install -y libopenblas-dev
     fi
+    runCmd CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS" FORCE_CMAKE=1 $pipCmd install llama-cpp-python huggingface_hub
   fi
-  ollamaModel="llama3.2:3b"
-  echo "getting model $ollamaModel ..." | tee -a $logFile
-  ollama pull $ollamaModel                 # get this model
-  if command -v systemctl &>/dev/null; then
-    runCmd sudo systemctl daemon-reload
-    runCmd sudo systemctl enable ollama
-    runCmd sudo systemctl restart ollama
-    cd $baseDir
-    generateServiceFiles                   # generate and install systemd service files dynamically
-    echo "Enabling systemd services..." | tee -a $logFile
-    runCmd sudo systemctl enable "$LOGS_MOUNT_UNIT"
-    runCmd sudo systemctl enable "$TMP_MOUNT_UNIT"
-    runCmd sudo systemctl enable minimy
+
+  echo "Pre-caching the LLM model from HuggingFace..." | tee -a $logFile
+  local llmRepo=$(grep "LLMRepo:" "$configFile" | awk '{print $2}' | tr -d \''"')
+  local llmFile=$(grep "LLMFile:" "$configFile" | awk '{print $2}' | tr -d \''"')
+
+  if [ -n "$llmRepo" ] && [ -n "$llmFile" ]; then
+    echo "Downloading model $llmRepo ($llmFile) ..." | tee -a $logFile
+    runCmd $pythonCmd -c "from huggingface_hub import hf_hub_download; hf_hub_download(repo_id='$llmRepo', filename='$llmFile')"
+  else
+    echo "Warning: LLMRepo or LLMFile not found in config. Skipping pre-cache." | tee -a $logFile
   fi
 
   # Set whisper to run as a system daemon and log to /var/log/whisper.log
@@ -521,7 +514,7 @@ hub=""                                     # hub server
 let lastSecs=$SECONDS
 timeSt=`date +"%y-%m-%d-%H-%M-%S"`
 logFile="$HOME/$timeSt-installminimy.out"  # output file
-if [ "$MINIMY_SAVELOGS" = "false" ]; then 
+if [ "$MINIMY_SAVELOGS" = "false" ]; then
   logFile="/dev/null"                      # if logging is disabled, log to /dev/null
 fi
 musicDir=""                                # directory with music files

--- a/install/mmconfig.yml.template
+++ b/install/mmconfig.yml.template
@@ -23,6 +23,8 @@
     Hub: localhost
     HubModel: base.en
     SpokeModel: tiny.en
+    LLMRepo: 'unsloth/Qwen3.5-2B-GGUF'
+    LLMFile: 'Qwen3.5-2B-Q6_K.gguf'
     MusicDir:
     WakeWords:
     - 'computer'

--- a/skills/system_skills/skill_fallback.py
+++ b/skills/system_skills/skill_fallback.py
@@ -62,7 +62,17 @@ class FallbackSkill(SimpleVoiceAssistant):
           )
 
         ans = output['choices'][0]['message']['content'].strip()
-        print(ans)        
+        
+        # log outputs alongside inputs to logs/llm.txt
+        import os
+        log_path = os.path.expanduser("~/minimy/logs/llm.txt")
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        try:
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write(f"Q: {ques}\nA: {ans}\n{'-'*40}\n")
+        except Exception as log_err:
+            self.log.error(f"FallbackSkill: Failed to write to {log_path}: {log_err}")
+            
       except Exception as e:
         self.log.error(f"FallbackSkill: Error querying local LLM: {e}")
         ans = "I encountered an error trying to process your request."

--- a/skills/system_skills/skill_fallback.py
+++ b/skills/system_skills/skill_fallback.py
@@ -2,21 +2,71 @@ from framework.util.utils import aplay, Config, execute_command
 from threading import Event
 import json
 from skills.sva_base import SimpleVoiceAssistant
+import re
+
+try:
+  from huggingface_hub import hf_hub_download
+  from llama_cpp import Llama
+except ImportError:
+  hf_hub_download = None
+  Llama = None
 
 class FallbackSkill(SimpleVoiceAssistant):
   def __init__(self, bus=None, timeout=5):
     super().__init__(msg_handler=self.handle_message, skill_id="fallback_skill", skill_category="fallback")
+    self.cfg = Config()
+    self.llm = None
+    if Llama is not None and hf_hub_download is not None:
+      self.llm_repo = self.cfg.get_cfg_val('Basic.LLMRepo')
+      self.llm_file = self.cfg.get_cfg_val('Basic.LLMFile')
+      
+      if not self.llm_repo or not self.llm_file:
+          self.log.error("FallbackSkill: LLM configuration missing (Basic.LLMRepo or Basic.LLMFile) in mmconfig.yml. Cannot load model.")
+      else:
+          self.log.info(f"FallbackSkill: Downloading/Loading LLM model from {self.llm_repo} ({self.llm_file})")
+          try:
+            model_path = hf_hub_download(repo_id=self.llm_repo, filename=self.llm_file)
+            self.llm = Llama(model_path=model_path, n_ctx=2048, verbose=False)
+          except Exception as e:
+            self.log.error(f"FallbackSkill: Failed to load Llama model: {e}")
+    else:
+      self.log.error("FallbackSkill: llama_cpp or huggingface_hub not installed")
 
   def handle_message(self, msg):
     self.log.info(f"FallbackSkill.handle_message() NOT EXPECTING THIS IS EVER CALLED!!!")
 
   def handle_fallback(self, msg):
-    # get an answer from the Ollama server
+    # get an answer from the local LLM
     self.log.debug(f"FallbackSkill:handle_fallback(): msg: \n{json.dumps(msg,indent=2)}")
     ques = msg["payload"]["utt"]["sentence"] # get the question
-    cmd = f"/usr/local/sbin/qa.py {ques}"
-    self.log.debug(f"FallbackSkill:handle_fallback(): calling cmd: {cmd}")
-    ans = execute_command(cmd)             # get answer from command
+    
+    ans = "I am sorry, my local language model is not available right now due to a configuration error."
+    if self.llm:
+      try:
+        messages = [
+          {"role": "system", "content": "You are a helpful and concise voice assistant for a smart boombox. Answer questions clearly and directly. Do not format with Markdown. Only speak in complete sentences that piper can transcribe."},
+          {"role": "user", "content": ques}
+        ]
+        
+        # We attempt to safely pass the kwarg to disable thinking internally as per llama.cpp defaults if supported by python bindings
+        try:
+          output = self.llm.create_chat_completion(
+            messages=messages,
+            max_tokens=150,
+            chat_template_kwargs={"enable_thinking": False}
+          )
+        except TypeError:
+          output = self.llm.create_chat_completion(
+            messages=messages,
+            max_tokens=150,
+          )
+
+        ans = output['choices'][0]['message']['content'].strip()
+        print(ans)        
+      except Exception as e:
+        self.log.error(f"FallbackSkill: Error querying local LLM: {e}")
+        ans = "I encountered an error trying to process your request."
+
     self.log.debug(f"FallbackSkill:handle_fallback(): ans: {ans}")
     self.speak(ans)                        # speak the answer
 


### PR DESCRIPTION
This makes it easier to switch models by defining the model in mmconfig.yml. This also removes the need for an LLM server to be running at all times, reducing complexity. In addition, this is faster.

I have also switched the model from llama3.2 3B to qwen3.5 2B. This is roughly 2/3 the size and thus faster, while improving in quality.